### PR TITLE
update deprecated boost url

### DIFF
--- a/com.github.Murmele.scram.yml
+++ b/com.github.Murmele.scram.yml
@@ -20,13 +20,13 @@ modules:
       - ./b2  variant=release -j $FLATPAK_BUILDER_N_JOBS install
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2
+        url: https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.bz2
         sha256: 475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39
         x-checker-data:
           type: anitya
           project-id: 6845
           stable-only: true
-          url-template: https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
+          url-template: https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
 
 # libxml2 is already in the sdk
   - name: scram


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
